### PR TITLE
Install production dependencies

### DIFF
--- a/football-predictor/frontend/Dockerfile
+++ b/football-predictor/frontend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
Update `npm ci` command to use `--omit=dev` because `--only=production` is deprecated.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbd51c12-276a-45fa-a12c-e13f9c3c8901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbd51c12-276a-45fa-a12c-e13f9c3c8901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

