### PR TITLE
Install production frontend dependencies

### DIFF
--- a/football-predictor/frontend/Dockerfile
+++ b/football-predictor/frontend/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --omit=dev
+# Install all dependencies (including dev dependencies for build)
+RUN npm install
 
 # Copy source code
 COPY . .
@@ -20,7 +20,7 @@ EXPOSE 3001
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:3001 || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3001 || exit 1
 
 # Start the application
 CMD ["npm", "start"]


### PR DESCRIPTION
Fix Docker build by using `npm install` and updating the health check to `wget`.

The original `npm ci --omit=dev` command failed because `package-lock.json` was missing and dev dependencies are required for the Next.js build process. `npm install` addresses both issues. The health check was updated from `curl` to `wget` for compatibility with the base image.

---
<a href="https://cursor.com/background-agent?bcId=bc-e34321ce-6e02-4dda-adb0-f5b9c8ff6604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e34321ce-6e02-4dda-adb0-f5b9c8ff6604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

