### PR TITLE
fix: improve Dockerfile build process

### DIFF
--- a/football-predictor/frontend/Dockerfile
+++ b/football-predictor/frontend/Dockerfile
@@ -10,13 +10,20 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install all dependencies (including dev dependencies for build)
-RUN npm install
+RUN npm ci --only=production=false
 
 # Copy source code
 COPY . .
 
-# Build the application
+# Set environment variables for build
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Build the application with verbose output
 RUN npm run build
+
+# Verify build was successful
+RUN ls -la .next/ && test -f .next/BUILD_ID
 
 # Expose port
 EXPOSE 3001


### PR DESCRIPTION
- Use npm ci for more reliable dependency installation
- Add environment variables for production build
- Add build verification step to ensure BUILD_ID exists
- Disable Next.js telemetry for cleaner builds

This should resolve the BUILD_ID error in the frontend container.