### PR TITLE
Fix invalid url error during build

### DIFF
--- a/football-predictor/frontend/lib/logger.ts
+++ b/football-predictor/frontend/lib/logger.ts
@@ -57,9 +57,18 @@ class Logger {
   }
 
   private async clearLogs() {
+    // Only make API calls in browser environment
+    if (typeof window === 'undefined') {
+      console.log('🧹 Skipping log clear during SSR/build')
+      return
+    }
+
     try {
+      // Get the API base URL from environment or use default
+      const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8003'
+      
       // Clear logs on backend
-      await fetch('/api/logs/clear', {
+      await fetch(`${apiBaseUrl}/api/logs/clear`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -75,12 +84,20 @@ class Logger {
   private async flushLogs() {
     if (this.logBuffer.length === 0) return
 
+    // Only make API calls in browser environment
+    if (typeof window === 'undefined') {
+      return
+    }
+
     const logsToFlush = [...this.logBuffer]
     this.logBuffer = []
 
     try {
+      // Get the API base URL from environment or use default
+      const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8003'
+      
       // Send logs to backend endpoint
-      const response = await fetch('/api/logs', {
+      const response = await fetch(`${apiBaseUrl}/api/logs`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Prevent logger API calls during Next.js build and use absolute URLs to fix `ERR_INVALID_URL` errors during static page generation.

During the Next.js build process, the `Logger` class's `clearLogs` and `flushLogs` methods were being invoked. These methods attempted to `fetch` data using relative URLs (e.g., `/api/logs/clear`), which is not supported in a server-side (static generation) context, leading to `TypeError: Failed to parse URL from /api/logs/clear`. This PR adds checks to ensure these API calls only execute in a browser environment and constructs API URLs using the `NEXT_PUBLIC_API_URL` environment variable for proper resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecd23f94-0546-43e3-a2d7-3745053b729d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecd23f94-0546-43e3-a2d7-3745053b729d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

